### PR TITLE
wagon: add initial doc + gofmt test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go:
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - tip
+
+sudo: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 wagon
 =====
 
+[![Build Status](https://travis-ci.org/go-interpreter/wagon.svg?branch=master)](https://travis-ci.org/go-interpreter/wagon)
+[![GoDoc](https://godoc.org/github.com/go-interpreter/wagon?status.svg)](https://godoc.org/github.com/go-interpreter/wagon)
+
 `wagon` is a [WebAssembly](http://webassembly.org)-based interpreter in [Go](https://golang.org), for [Go](https://golang.org).
 

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2017 The go-interpreter Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package wagon is a WebAssembly-based interpreter in Go, for Go.
+package wagon

--- a/wagon_test.go
+++ b/wagon_test.go
@@ -1,0 +1,40 @@
+// Copyright 2017 The go-interpreter Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package wagon
+
+import (
+	"bytes"
+	"os/exec"
+	"testing"
+)
+
+func TestGofmt(t *testing.T) {
+	exe, err := exec.LookPath("goimports")
+	if err != nil {
+		switch e := err.(type) {
+		case *exec.Error:
+			if e.Err == exec.ErrNotFound {
+				exe, err = exec.LookPath("gofmt")
+			}
+		}
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(exe, "-d", ".")
+	buf := new(bytes.Buffer)
+	cmd.Stdout = buf
+	cmd.Stderr = buf
+
+	err = cmd.Run()
+	if err != nil {
+		t.Fatalf("error running %s:\n%s\n%v", exe, string(buf.Bytes()), err)
+	}
+
+	if len(buf.Bytes()) != 0 {
+		t.Errorf("some files were not gofmt'ed:\n%s\n", string(buf.Bytes()))
+	}
+}


### PR DESCRIPTION
This CL adds an initial documentation placeholder for the wagon package.
It also adds a simple test to make sure files are being gofmt'ed.