### PR TITLE
wagon: enable travis fast-finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - master
 
 matrix:
+ fast_finish: true
  allow_failures:
    - go: master
 


### PR DESCRIPTION
This CL enables the fast-finish mode for travis.
See:
 https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-interpreter/wagon/20)
<!-- Reviewable:end -->
