### PR TITLE
exec: export the VM memory field

### DIFF
--- a/exec/vm.go
+++ b/exec/vm.go
@@ -134,6 +134,11 @@ func NewVM(module *wasm.Module) (*VM, error) {
 	return &vm, nil
 }
 
+// Memory returns the linear memory space for the VM.
+func (vm *VM) Memory() []byte {
+	return vm.memory
+}
+
 func (vm *VM) pushBool(v bool) {
 	if v {
 		vm.pushUint64(1)


### PR DESCRIPTION
Allows embedders to interact with a running module.

Fixes go-interpreter/wagon#42.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-interpreter/wagon/45)
<!-- Reviewable:end -->
