### PR TITLE
disasm: fix incorrect stack depth for end/discard

### DIFF
--- a/disasm/disasm.go
+++ b/disasm/disasm.go
@@ -184,7 +184,7 @@ func Disassemble(fn wasm.Function, module *wasm.Module) (*Disassembly, error) {
 			// Same with ops.Br/BrIf, we subtract 2 instead of 1
 			// to get the depth of the *parent* block of the branch
 			// we want to take.
-			prevDepthIndex := stackDepths.Len() - 2
+			prevDepthIndex := stackDepths.Len() - 1
 			prevDepth := stackDepths.Get(prevDepthIndex)
 
 			if op != ops.Else && blockSig != wasm.BlockTypeEmpty && !instr.Unreachable {


### PR DESCRIPTION
End/Discard ops were being misencoded with incorrect stack depths which caused stack underflows that manifested as `vm.ctx.stack` slice index out of bounds runtime panics.

[Test case wasm](https://dsc-misc.s3.amazonaws.com/wagon-test.wasm) (execute the exported function `_ZN4enol4InitEv`)

I'm not 100% familiar with the code in question, so please check if this is the correct fix but my test code runs correctly with this change applied.