### PR TITLE
RFC: Modules containing native functions

### DIFF
--- a/exec/call_test.go
+++ b/exec/call_test.go
@@ -1,0 +1,155 @@
+// Copyright 2018 The go-interpreter Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package exec
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/go-interpreter/wagon/wasm"
+)
+
+func TestHostCall(t *testing.T) {
+	const secretValue = 0xdeadbeef
+
+	var secretVariable int = 0
+
+	// a host function that can be called by WASM code.
+	testHostFunction := func() {
+		secretVariable = secretValue
+	}
+
+	m := wasm.NewModule()
+	m.Start = &wasm.SectionStartFunction{Index: 0}
+
+	// A function signature. Both the host and WASM function
+	// have the same signature.
+	fsig := wasm.FunctionSig{
+		Form:        0,
+		ParamTypes:  []wasm.ValueType{},
+		ReturnTypes: []wasm.ValueType{},
+	}
+
+	// List of all function types available in this module.
+	// There is only one: (func [] -> [])
+	m.Types = &wasm.SectionTypes{
+		Entries: []wasm.FunctionSig{fsig, fsig},
+	}
+
+	m.Function = &wasm.SectionFunctions{
+		Types: []uint32{0, 0},
+	}
+
+	// The body of the start function, that should only
+	// call the host function
+	fb := wasm.FunctionBody{
+		Module: m,
+		Locals: []wasm.LocalEntry{},
+		// code should disassemble to:
+		// call 1 (which is host)
+		// end
+		Code: []byte{0x02, 0x00, 0x10, 0x01, 0x0b},
+	}
+
+	// There was no call to `ReadModule` so this part emulates
+	// how the module object would look like if the function
+	// had been called.
+	m.FunctionIndexSpace = []wasm.Function{
+		{
+			Sig:  &fsig,
+			Body: &fb,
+		},
+		{
+			Sig:  &fsig,
+			Host: reflect.ValueOf(testHostFunction),
+		},
+	}
+
+	m.Code = &wasm.SectionCode{
+		Bodies: []wasm.FunctionBody{fb},
+	}
+
+	// Once called, NewVM will execute the module's main
+	// function.
+	vm, err := NewVM(m)
+	if err != nil {
+		t.Fatalf("Error creating VM: %v", vm)
+	}
+
+	if len(vm.funcs) < 1 {
+		t.Fatalf("Need at least a start function!")
+	}
+
+	// Only one entry, which should be a function
+	if secretVariable != secretValue {
+		t.Fatalf("x is %d instead of %d", secretVariable, secretValue)
+	}
+}
+
+var moduleCallHost = []byte{
+	0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00, 0x01, 0x1A, 0x06, 0x60, 0x01, 0x7F, 0x00, 0x60,
+	0x01, 0x7F, 0x01, 0x7F, 0x60, 0x00, 0x01, 0x7F, 0x60, 0x00, 0x00, 0x60, 0x00, 0x01, 0x7C, 0x60,
+	0x01, 0x7F, 0x01, 0x7F, 0x02, 0x0F, 0x01, 0x03, 0x65, 0x6E, 0x76, 0x07, 0x5F, 0x6E, 0x61, 0x74,
+	0x69, 0x76, 0x65, 0x00, 0x05, 0x03, 0x02, 0x01, 0x02, 0x04, 0x04, 0x01, 0x70, 0x00, 0x02, 0x06,
+	0x10, 0x03, 0x7F, 0x01, 0x41, 0x00, 0x0B, 0x7F, 0x01, 0x41, 0x00, 0x0B, 0x7F, 0x00, 0x41, 0x01,
+	0x0B, 0x07, 0x09, 0x01, 0x05, 0x5F, 0x6D, 0x61, 0x69, 0x6E, 0x00, 0x01, 0x09, 0x01, 0x00, 0x0A,
+	0x08, 0x01, 0x06, 0x00, 0x41, 0x00, 0x10, 0x00, 0x0B,
+}
+
+func add3(x int32) int32 {
+	return x + 3
+}
+
+func importer(name string) (*wasm.Module, error) {
+	m := wasm.NewModule()
+	m.Types = &wasm.SectionTypes{
+		// List of all function types available in this module.
+		// There is only one: (func [int32] -> [int32])
+		Entries: []wasm.FunctionSig{
+			{
+				Form:        0,
+				ParamTypes:  []wasm.ValueType{wasm.ValueTypeI32},
+				ReturnTypes: []wasm.ValueType{wasm.ValueTypeI32},
+			},
+		},
+	}
+	m.FunctionIndexSpace = []wasm.Function{
+		{
+			Sig:  &m.Types.Entries[0],
+			Host: reflect.ValueOf(add3),
+			Body: &wasm.FunctionBody{},
+		},
+	}
+	m.Export = &wasm.SectionExports{
+		Entries: map[string]wasm.ExportEntry{
+			"_native": {
+				FieldStr: "_naive",
+				Kind:     wasm.ExternalFunction,
+				Index:    0,
+			},
+		},
+	}
+
+	return m, nil
+}
+
+func TestHostSymbolCall(t *testing.T) {
+	m, err := wasm.ReadModule(bytes.NewReader(moduleCallHost), importer)
+	if err != nil {
+		t.Fatalf("Could not read module: %v", err)
+	}
+	vm, err := NewVM(m)
+	if err != nil {
+		t.Fatalf("Could not instantiate vm: %v", err)
+	}
+	rtrns, err := vm.ExecCode(1)
+	if err != nil {
+		t.Fatalf("Error executing the default function: %v", err)
+	}
+	if int(rtrns.(uint32)) != 3 {
+		t.Fatalf("Did not get the right value. Got %d, wanted %d", rtrns, 3)
+	}
+}

--- a/exec/func.go
+++ b/exec/func.go
@@ -45,7 +45,7 @@ func (fn goFunction) call(vm *VM, index int64) {
 		case reflect.Uint32, reflect.Uint64:
 			val.SetUint(raw)
 		case reflect.Int32, reflect.Int64:
-			val.SetUint(raw)
+			val.SetInt(int64(raw))
 		default:
 			panic(fmt.Sprintf("exec: args %d invalid kind=%v", i, kind))
 		}

--- a/wasm/module.go
+++ b/wasm/module.go
@@ -7,6 +7,7 @@ package wasm
 import (
 	"errors"
 	"io"
+	"reflect"
 
 	"github.com/go-interpreter/wagon/wasm/internal/readpos"
 )
@@ -22,6 +23,13 @@ const (
 type Function struct {
 	Sig  *FunctionSig
 	Body *FunctionBody
+	Host reflect.Value
+}
+
+// IsHost indicates whether this function is a host function as defined in:
+//  https://webassembly.github.io/spec/core/exec/modules.html#host-functions
+func (fct *Function) IsHost() bool {
+	return fct.Host != reflect.Value{}
 }
 
 // Module represents a parsed WebAssembly module:
@@ -44,6 +52,7 @@ type Module struct {
 	// The function index space of the module
 	FunctionIndexSpace []Function
 	GlobalIndexSpace   []GlobalEntry
+
 	// function indices into the global function space
 	// the limit of each table is its capacity (cap)
 	TableIndexSpace        [][]uint32
@@ -56,6 +65,21 @@ type Module struct {
 		Globals  int
 		Tables   int
 		Memories int
+	}
+}
+
+// NewModule creates a new empty module
+func NewModule() *Module {
+	return &Module{
+		Types:    &SectionTypes{},
+		Import:   &SectionImports{},
+		Table:    &SectionTables{},
+		Memory:   &SectionMemories{},
+		Global:   &SectionGlobals{},
+		Export:   &SectionExports{},
+		Start:    &SectionStartFunction{},
+		Elements: &SectionElements{},
+		Data:     &SectionData{},
 	}
 }
 


### PR DESCRIPTION
In its current state, this PR is a request for comments.

The context of this PR:
  * Use the wagon interpreter as a library in a bigger project and use it as a WASM interpreter;
  * The client code wants to make some of its internal functions available to the client.

The approach that is undertaken in this PR is to add a `NativeFunctions` section to `Module`, that lists the "native" functions to be called by the interpreter. It also adds a `Native` flag to the`Function` struct, which is false by default.
When the interpreter encounters a `call` opcode, the `Native` flag is checked. If it is true, then a function is called.

This approach has issues I'm already aware of:
  * `NativeFunctions` is not specified in the standard
  * it makes module version management more difficult

In its current state, the PR has shortcomings that can be fixed:
  * native code might panic
  * it doesn't support calling functions with parameters
  * `call_indirect` is not currently supported

I'm looking forward to hearing your thoughts on the matter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-interpreter/wagon/58)
<!-- Reviewable:end -->
