### PR TITLE
Pass the VM pointer to host go functions

### DIFF
--- a/exec/call_test.go
+++ b/exec/call_test.go
@@ -15,10 +15,10 @@ import (
 func TestHostCall(t *testing.T) {
 	const secretValue = 0xdeadbeef
 
-	var secretVariable int = 0
+	var secretVariable int
 
 	// a host function that can be called by WASM code.
-	testHostFunction := func() {
+	testHostFunction := func(proc *Process) {
 		secretVariable = secretValue
 	}
 
@@ -99,11 +99,11 @@ var moduleCallHost = []byte{
 	0x08, 0x01, 0x06, 0x00, 0x41, 0x00, 0x10, 0x00, 0x0B,
 }
 
-func add3(x int32) int32 {
+func add3(proc *Process, x int32) int32 {
 	return x + 3
 }
 
-func importer(name string) (*wasm.Module, error) {
+func importer(name string, f func(*Process, int32) int32) (*wasm.Module, error) {
 	m := wasm.NewModule()
 	m.Types = &wasm.SectionTypes{
 		// List of all function types available in this module.
@@ -119,7 +119,44 @@ func importer(name string) (*wasm.Module, error) {
 	m.FunctionIndexSpace = []wasm.Function{
 		{
 			Sig:  &m.Types.Entries[0],
-			Host: reflect.ValueOf(add3),
+			Host: reflect.ValueOf(f),
+			Body: &wasm.FunctionBody{},
+		},
+	}
+	m.Export = &wasm.SectionExports{
+		Entries: map[string]wasm.ExportEntry{
+			"_native": {
+				FieldStr: "_naive",
+				Kind:     wasm.ExternalFunction,
+				Index:    0,
+			},
+		},
+	}
+
+	return m, nil
+}
+
+func invalidAdd3(x int32) int32 {
+	return x + 3
+}
+
+func invalidImporter(name string) (*wasm.Module, error) {
+	m := wasm.NewModule()
+	m.Types = &wasm.SectionTypes{
+		// List of all function types available in this module.
+		// There is only one: (func [int32] -> [int32])
+		Entries: []wasm.FunctionSig{
+			{
+				Form:        0,
+				ParamTypes:  []wasm.ValueType{wasm.ValueTypeI32},
+				ReturnTypes: []wasm.ValueType{wasm.ValueTypeI32},
+			},
+		},
+	}
+	m.FunctionIndexSpace = []wasm.Function{
+		{
+			Sig:  &m.Types.Entries[0],
+			Host: reflect.ValueOf(invalidAdd3),
 			Body: &wasm.FunctionBody{},
 		},
 	}
@@ -137,7 +174,7 @@ func importer(name string) (*wasm.Module, error) {
 }
 
 func TestHostSymbolCall(t *testing.T) {
-	m, err := wasm.ReadModule(bytes.NewReader(moduleCallHost), importer)
+	m, err := wasm.ReadModule(bytes.NewReader(moduleCallHost), func(n string) (*wasm.Module, error) { return importer(n, add3) })
 	if err != nil {
 		t.Fatalf("Could not read module: %v", err)
 	}
@@ -151,5 +188,52 @@ func TestHostSymbolCall(t *testing.T) {
 	}
 	if int(rtrns.(uint32)) != 3 {
 		t.Fatalf("Did not get the right value. Got %d, wanted %d", rtrns, 3)
+	}
+}
+
+func TestGoFunctionCallChecksForFirstArgument(t *testing.T) {
+	m, err := wasm.ReadModule(bytes.NewReader(moduleCallHost), invalidImporter)
+	if err != nil {
+		t.Fatalf("Could not read module: %v", err)
+	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("This code should have panicked.")
+		} else {
+			if r != "exec: the first argument of a host function was int32, expected ptr" {
+				t.Errorf("This should have panicked because of the wrong type being used as a first argument, and it panicked because of %v", r)
+			}
+		}
+	}()
+	vm, err := NewVM(m)
+	if err != nil {
+		t.Fatalf("Could not instantiate vm: %v", err)
+	}
+	_, err = vm.ExecCode(1)
+	if err != nil {
+		t.Fatalf("Error executing the default function: %v", err)
+	}
+}
+
+func terminate(proc *Process, x int32) int32 {
+	proc.Terminate()
+	return 3
+}
+
+func TestHostTerminate(t *testing.T) {
+	m, err := wasm.ReadModule(bytes.NewReader(moduleCallHost), func(n string) (*wasm.Module, error) { return importer(n, terminate) })
+	if err != nil {
+		t.Fatalf("Could not read module: %v", err)
+	}
+	vm, err := NewVM(m)
+	if err != nil {
+		t.Fatalf("Could not instantiate vm: %v", err)
+	}
+	_, err = vm.ExecCode(1)
+	if err != nil {
+		t.Fatalf("Error executing the default function: %v", err)
+	}
+	if vm.abort == false || vm.ctx.pc > 0xa {
+		t.Fatalf("Terminate did not abort execution: abort=%v, pc=%#x", vm.abort, vm.ctx.pc)
 	}
 }

--- a/exec/vm_test.go
+++ b/exec/vm_test.go
@@ -1,0 +1,112 @@
+// Copyright 2018 The go-interpreter Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package exec
+
+import (
+	"testing"
+)
+
+var (
+	smallMemoryVM      = &VM{memory: []byte{1, 2, 3}}
+	emptyMemoryVM      = &VM{memory: []byte{}}
+	smallMemoryProcess = &Process{vm: smallMemoryVM}
+	emptyMemoryProcess = &Process{vm: emptyMemoryVM}
+	tooBigABuffer      = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}
+)
+
+func TestNormalWrite(t *testing.T) {
+	vm := &VM{memory: make([]byte, 300)}
+	proc := &Process{vm: vm}
+	n, err := proc.WriteAt(tooBigABuffer, 0)
+	if err != nil {
+		t.Fatalf("Found an error when writing: %v", err)
+	}
+	if n != len(tooBigABuffer) {
+		t.Fatalf("Number of written bytes was %d, should have been %d", n, len(tooBigABuffer))
+	}
+}
+
+func TestWriteBoundary(t *testing.T) {
+	n, err := smallMemoryProcess.WriteAt(tooBigABuffer, 0)
+	if err == nil {
+		t.Fatal("Should have reported an error and didn't")
+	}
+	if n != len(smallMemoryVM.memory) {
+		t.Fatalf("Number of written bytes was %d, should have been 0", n)
+	}
+}
+
+func TestReadBoundary(t *testing.T) {
+	buf := make([]byte, 300)
+	n, err := smallMemoryProcess.ReadAt(buf, 0)
+	if err == nil {
+		t.Fatal("Should have reported an error and didn't")
+	}
+	if n != len(smallMemoryVM.memory) {
+		t.Fatalf("Number of written bytes was %d, should have been 0", n)
+	}
+}
+
+func TestReadEmpty(t *testing.T) {
+	buf := make([]byte, 300)
+	n, err := emptyMemoryProcess.ReadAt(buf, 0)
+	if err == nil {
+		t.Fatal("Should have reported an error and didn't")
+	}
+	if n != 0 {
+		t.Fatalf("Number of written bytes was %d, should have been 0", n)
+	}
+}
+
+func TestReadOffset(t *testing.T) {
+	buf0 := make([]byte, 2)
+	n0, err := smallMemoryProcess.ReadAt(buf0, 0)
+	if err != nil {
+		t.Fatalf("Error reading 1-byte buffer: %v", err)
+	}
+	if n0 != 2 {
+		t.Fatalf("Read %d bytes, expected 2", n0)
+	}
+
+	buf1 := make([]byte, 1)
+	n1, err := smallMemoryProcess.ReadAt(buf1, 1)
+	if err != nil {
+		t.Fatalf("Error reading 1-byte buffer: %v", err)
+	}
+	if n1 != 1 {
+		t.Fatalf("Read %d bytes, expected 1.", n0)
+	}
+
+	if buf0[1] != buf1[0] {
+		t.Fatal("Read two different bytes from what should be the same location")
+	}
+}
+
+func TestWriteEmpty(t *testing.T) {
+	n, err := emptyMemoryProcess.WriteAt(tooBigABuffer, 0)
+	if err == nil {
+		t.Fatal("Should have reported an error and didn't")
+	}
+	if n != 0 {
+		t.Fatalf("Number of written bytes was %d, should have been 0", n)
+	}
+}
+
+func TestWriteOffset(t *testing.T) {
+	vm := &VM{memory: make([]byte, 300)}
+	proc := &Process{vm: vm}
+
+	n, err := proc.WriteAt(tooBigABuffer, 2)
+	if err != nil {
+		t.Fatalf("error writing to buffer: %v", err)
+	}
+	if n != len(tooBigABuffer) {
+		t.Fatalf("Number of written bytes was %d, should have been %d", n, len(tooBigABuffer))
+	}
+
+	if vm.memory[0] != 0 || vm.memory[1] != 0 || vm.memory[2] != tooBigABuffer[0] {
+		t.Fatal("Writing at offset didn't work")
+	}
+}


### PR DESCRIPTION
The previous PR #58 was enabling go functions, but without the VM context being passed, they can only do so much. This PR enforces that host Go functions are passed a `*VM` parameter as their first argument.

Another idea would be to check for pointers in the list of arguments, and pass a `*VM` each time that an argument is being encountered. It has some advantages, like streamlining the code and letting the Go type system handle the `panic`s for us. This being said, this leaves too much room for abuse since users could write confusing functions that take that pointer in the middle of their arguments list, thus disturbing the order to the WASM call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-interpreter/wagon/59)
<!-- Reviewable:end -->
