### PR TITLE
fix data init order

### DIFF
--- a/wasm/index.go
+++ b/wasm/index.go
@@ -158,8 +158,8 @@ func (m *Module) populateLinearMemory() error {
 		memory := m.LinearMemoryIndexSpace[int(entry.Index)]
 		if int(offset)+len(entry.Data) > len(memory) {
 			data := make([]byte, int(offset)+len(entry.Data))
-			copy(data[offset:], entry.Data)
 			copy(data, memory)
+			copy(data[offset:], entry.Data)
 			m.LinearMemoryIndexSpace[int(entry.Index)] = data
 		} else {
 			copy(memory[int(offset):], entry.Data)


### PR DESCRIPTION
WASM files declaring overlapping data sections would not end up with the proper state as accepted by binaryen.

This PR simply makes sure that the newly created memory is first initialized with the previous content of the memory before it is overwritten with the content from the next data segment.