### PR TITLE
exec: Add a function to re-use a VM that was Terminated

### DIFF
--- a/exec/native_compile_test.go
+++ b/exec/native_compile_test.go
@@ -86,9 +86,9 @@ func TestNativeAsmStructureSetup(t *testing.T) {
 	// setup mocks.
 	nc.Scanner.(*mockSequenceScanner).emit = []compile.CompilationCandidate{
 		// Sequence with single integer op - should not compiled.
-		compile.CompilationCandidate{Start: 0, End: 7, EndInstruction: 4, Metrics: compile.Metrics{IntegerOps: 1}},
+		{Start: 0, End: 7, EndInstruction: 4, Metrics: compile.Metrics{IntegerOps: 1}},
 		// Sequence with two integer ops - should be emitted.
-		compile.CompilationCandidate{Start: 7, End: 15, StartInstruction: 4, EndInstruction: 10, Metrics: compile.Metrics{IntegerOps: 2}},
+		{Start: 7, End: 15, StartInstruction: 4, EndInstruction: 10, Metrics: compile.Metrics{IntegerOps: 2}},
 	}
 
 	if err := vm.tryNativeCompile(); err != nil {

--- a/exec/vm.go
+++ b/exec/vm.go
@@ -168,6 +168,16 @@ func NewVM(module *wasm.Module, opts ...VMOption) (*VM, error) {
 		}
 	}
 
+	if options.EnableAOT {
+		supportedBackend, backend := nativeBackend()
+		if supportedBackend {
+			vm.nativeBackend = backend
+			if err := vm.tryNativeCompile(); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	return &vm, nil
 }
 
@@ -186,16 +196,6 @@ func (vm *VM) resetGlobals() error {
 			vm.globals[i] = uint64(math.Float32bits(v))
 		case float64:
 			vm.globals[i] = uint64(math.Float64bits(v))
-		}
-	}
-
-	if options.EnableAOT {
-		supportedBackend, backend := nativeBackend()
-		if supportedBackend {
-			vm.nativeBackend = backend
-			if err := vm.tryNativeCompile(); err != nil {
-				return nil, err
-			}
 		}
 	}
 

--- a/exec/vm.go
+++ b/exec/vm.go
@@ -450,6 +450,11 @@ outer:
 	return 0
 }
 
+// Restart readies the VM for another run.
+func (vm *VM) Restart() {
+	vm.abort = false
+}
+
 // Close frees any resources managed by the VM.
 func (vm *VM) Close() error {
 	vm.abort = true // prevents further use.


### PR DESCRIPTION
When a VM has been terminated, it can not be re-used. By implementing a `Restart` function that clears the `abort` flag, clients of the `VM` interface can re-use a given VM.