### PR TITLE
Fixes panic on terminate for return values

### DIFF
--- a/exec/vm.go
+++ b/exec/vm.go
@@ -452,7 +452,7 @@ outer:
 		}
 	}
 
-	if compiled.returns {
+	if compiled.returns && !vm.abort {
 		return vm.ctx.stack[len(vm.ctx.stack)-1]
 	}
 	return 0


### PR DESCRIPTION
If you call `proc.Terminate()` in an external function, sometimes the VM will expect a return value on the stack even though there isn't one there because the function didn't finish. In this case, we should ignore the return value from the function.