### PR TITLE
Fix type conversion panic for host-provided funcs

### DIFF
--- a/exec/native_compile.go
+++ b/exec/native_compile.go
@@ -91,7 +91,7 @@ func (vm *VM) tryNativeCompile() error {
 	}
 
 	for i := range vm.funcs {
-		if _, isGoFunc := vm.funcs[i].(*goFunction); isGoFunc {
+		if _, isGoFunc := vm.funcs[i].(goFunction); isGoFunc {
 			continue
 		}
 


### PR DESCRIPTION
It was panicking because it's of type goFunction, not *goFunction as the line is checking for.