### PR TITLE
Fix shift instructions

### DIFF
--- a/exec/num.go
+++ b/exec/num.go
@@ -76,19 +76,19 @@ func (vm *VM) i32Xor() {
 func (vm *VM) i32Shl() {
 	v2 := vm.popUint32()
 	v1 := vm.popUint32()
-	vm.pushUint32(v1 << v2)
+	vm.pushUint32(v1 << (v2 % 32))
 }
 
 func (vm *VM) i32ShrU() {
 	v2 := vm.popUint32()
 	v1 := vm.popUint32()
-	vm.pushUint32(v1 >> v2)
+	vm.pushUint32(v1 >> (v2 % 32))
 }
 
 func (vm *VM) i32ShrS() {
 	v2 := vm.popUint32()
 	v1 := vm.popInt32()
-	vm.pushInt32(v1 >> v2)
+	vm.pushInt32(v1 >> (v2 % 32))
 }
 
 func (vm *VM) i32Rotl() {
@@ -230,19 +230,19 @@ func (vm *VM) i64Xor() {
 func (vm *VM) i64Shl() {
 	v2 := vm.popUint64()
 	v1 := vm.popUint64()
-	vm.pushUint64(v1 << v2)
+	vm.pushUint64(v1 << (v2 % 64))
 }
 
 func (vm *VM) i64ShrS() {
 	v2 := vm.popUint64()
 	v1 := vm.popInt64()
-	vm.pushInt64(v1 >> v2)
+	vm.pushInt64(v1 >> (v2 % 64))
 }
 
 func (vm *VM) i64ShrU() {
 	v2 := vm.popUint64()
 	v1 := vm.popUint64()
-	vm.pushUint64(v1 >> v2)
+	vm.pushUint64(v1 >> (v2 % 64))
 }
 
 func (vm *VM) i64Rotl() {

--- a/exec/num_test.go
+++ b/exec/num_test.go
@@ -11,6 +11,72 @@ import (
 	"github.com/go-interpreter/wagon/wasm/operators"
 )
 
+func TestI32BinOps(t *testing.T) {
+	for _, tc := range []struct {
+		opcode byte
+		z1     int32
+		z2     int32
+		want   int32
+	}{
+		{operators.I32Shl, -1, 8, -256},
+		{operators.I32Shl, -1, 200, -256},
+		{operators.I32ShrS, -1, 8, -1},
+		{operators.I32ShrS, -1, 200, -1},
+		{operators.I32ShrU, -1, 8, 0xFFFFFF},
+		{operators.I32ShrU, -1, 200, 0xFFFFFF},
+		{operators.I32Rotl, 0x12345678, 8, 0x34567812},
+		{operators.I32Rotl, 0x12345678, 200, 0x34567812},
+	} {
+		name, err := operators.New(tc.opcode)
+		if err != nil {
+			t.Fatalf("could not lookup operator 0x%x: %+v", tc.opcode, name)
+		}
+		t.Run(fmt.Sprintf("%v(%v,%v)", name, tc.z1, tc.z2), func(t *testing.T) {
+			vm := new(VM)
+			vm.newFuncTable()
+			vm.pushInt32(tc.z1)
+			vm.pushInt32(tc.z2)
+			vm.funcTable[tc.opcode]()
+			if got, want := vm.popInt32(), tc.want; got != want {
+				t.Fatalf("got=%v, want=%v", got, want)
+			}
+		})
+	}
+}
+
+func TestI64BinOps(t *testing.T) {
+	for _, tc := range []struct {
+		opcode byte
+		z1     int64
+		z2     int64
+		want   int64
+	}{
+		{operators.I64Shl, -1, 8, -256},
+		{operators.I64Shl, -1, 200, -256},
+		{operators.I64ShrS, -1, 8, -1},
+		{operators.I64ShrS, -1, 200, -1},
+		{operators.I64ShrU, -1, 8, 0xFFFFFFFFFFFFFF},
+		{operators.I64ShrU, -1, 200, 0xFFFFFFFFFFFFFF},
+		{operators.I64Rotl, 0x1234567812345678, 8, 0x3456781234567812},
+		{operators.I64Rotl, 0x1234567812345678, 200, 0x3456781234567812},
+	} {
+		name, err := operators.New(tc.opcode)
+		if err != nil {
+			t.Fatalf("could not lookup operator 0x%x: %+v", tc.opcode, name)
+		}
+		t.Run(fmt.Sprintf("%v(%v,%v)", name, tc.z1, tc.z2), func(t *testing.T) {
+			vm := new(VM)
+			vm.newFuncTable()
+			vm.pushInt64(tc.z1)
+			vm.pushInt64(tc.z2)
+			vm.funcTable[tc.opcode]()
+			if got, want := vm.popInt64(), tc.want; got != want {
+				t.Fatalf("got=%v, want=%v", got, want)
+			}
+		})
+	}
+}
+
 func TestF32BinOps(t *testing.T) {
 	for _, tc := range []struct {
 		opcode byte


### PR DESCRIPTION
Hi, as the [Wasm Spec](https://webassembly.github.io/spec/core/exec/numerics.html#op-ishl) said, all shift instructions should mod the second arg: `Let k be i2 modulo N.` . And [here](https://webassembly.studio/?f=qn4yobte40g) is a simple online test case. I have fixed this bug and added some unit tests. Please double check this.